### PR TITLE
Add schema validator

### DIFF
--- a/examples/fmt-43.json
+++ b/examples/fmt-43.json
@@ -1,0 +1,127 @@
+{
+    "puid": "fmt/43",
+    "puidNamespace": "http://www.nationalarchives.gov.uk/",
+    "name": "JPEG File Interchange Format",
+    "version": "1.01",
+    "aliases": [
+        "JFIF (1.01)"
+    ],
+    "types": [
+        "Image (Raster)"
+    ],
+    "disclosure": "full",
+    "description": "The JPEG File Interchange Format (JFIF) is a file format for storing JPEG-compressed raster images. It was developed by the Independent JPEG Group and C-Cube Microsystems, in the absence of any such format being defined in the JPEG standard, and rapidly became a de facto standard; this is what is commonly referred to as the JPEG file format. A JFIF file comprises a JPEG data stream together with a JFIF marker. It begins with a Start of Image (SOI) marker, immediately followed by a JFIF Application (APP0). This is followed by the JPEG image data, which is terminated by an End of Image (EOI) marker. JFIF supports up to 24-bit colour and uses lossy compression (based on the Discrete Cosine Transform algorithm). Other types of compression are available through JPEG extensions, including progressive image buildup, arithmetic encoding, variable quantization, selective refinement, image tiling, and lossless compression, but these may not be supported by all JFIF readers and writers.",
+    "binaryFileFormat": "Binary",
+    "byteOrders": [
+        "Big-endian (Motorola)"
+    ],
+    "provenance": {
+        "provenanceSourceId": "1",
+        "provenanceSourceNamespace": "http://www.nationalarchives.gov.uk/",
+        "provenanceName": "Digital Preservation Department / The National Archives",
+        "provenanceSourceDate": "2005-03-11"
+    },
+    "lastUpdatedDate": "2005-08-02",
+    "identifiers": [
+        {
+            "identifier": "fmt/43",
+            "identifierType": "PUID"
+        },
+        {
+            "identifier": "image/jpeg",
+            "identifierType": "MIME"
+        },
+        {
+            "identifier": "public.jpeg",
+            "identifierType": "Apple Uniform Type Identifier"
+        }
+    ],
+    "developers": [
+        {
+            "developerId": "1",
+            "developerIdNamespace": "http://www.nationalarchives.gov.uk/",
+            "organisationName": "Independent JPEG Group",
+            "developerCompoundName": "Independent JPEG Group"
+        }
+    ],
+    "externalSignatures": [
+        {
+            "externalSignatureId": "665",
+            "externalSignatureIdNamespace": "http://www.nationalarchives.gov.uk/",
+            "signature": "jpg",
+            "signatureType": "File extension"
+        },
+        {
+            "externalSignatureId": "694",
+            "externalSignatureIdNamespace": "http://www.nationalarchives.gov.uk/",
+            "signature": "jpe",
+            "signatureType": "File extension"
+        },
+        {
+            "externalSignatureId": "736",
+            "externalSignatureIdNamespace": "http://www.nationalarchives.gov.uk/",
+            "signature": "jpeg",
+            "signatureType": "File extension"
+        }
+    ],
+    "internalSignatures": [
+        {
+            "signatureId": "67",
+            "signatureIdNamespace": "http://www.nationalarchives.gov.uk/",
+            "signatureName": "JFIF 1.01",
+            "signatureNote": "SOI and APP0 markers at BOF, EOI marker at EOF",
+            "byteSequences": [
+                {
+                    "byteSequenceId": "170",
+                    "byteSequenceIdNamespace": "http://www.nationalarchives.gov.uk/",
+                    "positionType": "Absolute from BOF",
+                    "offset": "0",
+                    "byteSequenceValue": "FFD8FFE0{2}4A464946000101(00|01|02)"
+                },
+                {
+                    "byteSequenceId": "171",
+                    "byteSequenceIdNamespace": "http://www.nationalarchives.gov.uk/",
+                    "positionType": "Absolute from EOF",
+                    "offset": "0",
+                    "maxOffset": "65536",
+                    "byteSequenceValue": "FFD9"
+                }
+            ]
+        }
+    ],
+    "relatedFormats": [
+        {
+            "relationshipType": "Has priority over",
+            "relatedFormatId": "fmt/41",
+            "relatedFormatIdNamespace": "http://www.nationalarchives.gov.uk/",
+            "relatedFormatName": "Raw JPEG Stream"
+        },
+        {
+            "relationshipType": "Is previous version of",
+            "relatedFormatId": "fmt/44",
+            "relatedFormatIdNamespace": "http://www.nationalarchives.gov.uk/",
+            "relatedFormatName": "JPEG File Interchange Format",
+            "relatedFormatVersion": "1.00"
+        },
+        {
+            "relationshipType": "Is subsequent version of",
+            "relatedFormatId": "fmt/42",
+            "relatedFormatIdNamespace": "http://www.nationalarchives.gov.uk/",
+            "relatedFormatName": "JPEG File Interchange Format",
+            "relatedFormatVersion": "1.01"
+        }
+    ],
+    "registryVersions": [
+        {
+            "registryNamespace": "http://www.nationalarchives.gov.uk/PRONOM",
+            "name": "DROID Signature File",
+            "version": "93"
+        },
+        {
+            "registryNamespace": "https://preservica.com/Registry",
+            "name": "Preservica Release",
+            "version": "5.10"
+        }
+    ],
+    "localLastModifiedDate": "2018-06-14T15:00:00.0Z"
+}

--- a/examples/md5check.json
+++ b/examples/md5check.json
@@ -1,0 +1,45 @@
+{
+    "preservationActionName": "MD5 Checksum Validation Using md5sum",
+    "preservationActionID": "MD5CheckMD5Sum",
+    "preservationActionDescription": "Validation of an MD5 checksum on a File using md5sum",
+    "preservationActionExample": " commandline 'md5sum -c manifest.md5', where manifest.md5 contains a MD5 checksum for a file called inputfile",
+    "preservationActionType": {
+        "preservationActionTypeID": "fix",
+        "preservationActionType": "fixity check",
+        "preservationActionTypeURI": "http://id.loc.gov/vocabulary/preservation/eventType/fix"
+    },
+    "inputs": [
+        {
+            "inputItemName": "manifest.md5",
+            "inputItemType": "File",
+            "inputItemDescription": "Manifest file containing the MD5 and name of the file to be checked",
+            "inputItemBinding": {
+                "prefix": "-c",
+                "position": 1
+            },
+            "secondaryFiles": [
+                {
+                    "secondaryFileName": "inputfile",
+                    "secondaryFileDescription": "The file that needs checking"
+                }
+            ]
+        }
+    ],
+    "outputs": [
+        {
+            "outputItemName": "pass_fail",
+            "outputItemDescription": "Fixity PASS or FAIL",
+            "outputItemType": "stdout",
+            "outputItemMapping": {
+                "outputMappingExpression": "grep -o -e 'FAILED' -e 'OK' | sed 's/OK/PASS/g' | sed 's/FAILED/FAIL/g'",
+                "outputMappingExpressionType": "shell script",
+                "outputMapping": {
+                    "parPropertyId": "fixityStatus"
+                }
+            }
+        }
+    ],
+    "tool": {
+        "toolIdentifier": "md5sum"
+    }
+}

--- a/examples/md5sum.json
+++ b/examples/md5sum.json
@@ -1,0 +1,4 @@
+{
+    "toolName": "md5sum",
+    "toolId": "md5sum"
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+jsonschema

--- a/schemas/format.json
+++ b/schemas/format.json
@@ -1,5 +1,5 @@
 {
-    "$id": "https://www.par.org/core/format.json/#",
+    "$id": "http://www.parcore.org/schema/format.json/#",
     "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "provenanceInformation": {
@@ -25,7 +25,8 @@
             "required": [
                 "provenanceSourceId",
                 "provenanceSourceNamespace"
-            ]
+            ],
+            "additionalProperties": false
         },
         "environmentInformation": {
             "type": "string"
@@ -43,7 +44,8 @@
             "required": [
                 "identifier",
                 "identifierType"
-            ]
+            ],
+            "additionalProperties": false
         },
         "documentInformation": {
             "type": "object",
@@ -79,16 +81,17 @@
                     "type": "string"
                 },
                 "author": {
-                    "$ref": "#/definitions/authorInformation"
+                    "$ref": "http://www.parcore.org/schema/format.json/#/definitions/authorInformation"
                 },
                 "publisher": {
-                    "$ref": "#/definitions/publisherInformation"
-                },
+                    "$ref": "http://www.parcore.org/schema/format.json/#/definitions/publisherInformation"
+                }
             },
             "required": [
                 "documentId",
                 "documentIdNamespace"
-            ]
+            ],
+            "additionalProperties": false
         },
         "relatedFormatInformation": {
             "type": "object",
@@ -113,7 +116,8 @@
                 "relationshipType",
                 "relatedFormatId",
                 "relatedFormatIdNamespace"
-            ]
+            ],
+            "additionalProperties": false
         },
         "authorInformation": {
             "type": "object",
@@ -137,7 +141,8 @@
             "required": [
                 "authorId",
                 "authorIdNamespace"
-            ]
+            ],
+            "additionalProperties": false
         },
         "publisherInformation": {
             "type": "object",
@@ -161,7 +166,8 @@
             "required": [
                 "publisherId",
                 "publisherIdNamespace"
-            ]
+            ],
+            "additionalProperties": false
         },
         "internalSignatureInformation": {
             "type": "object",
@@ -181,14 +187,15 @@
                 "byteSequences": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/byteSequenceInformation"
+                        "$ref": "http://www.parcore.org/schema/format.json/#/definitions/byteSequenceInformation"
                     }
                 }
             },
             "required": [
                 "signatureId",
                 "signatureIdNamespace"
-            ]
+            ],
+            "additionalProperties": false
         },
         "externalSignatureInformation": {
             "type": "object",
@@ -206,7 +213,7 @@
                     "type": "string"
                 }
             },
-            "required": []
+            "additionalProperties": false
         },
         "byteSequenceInformation": {
             "type": "object",
@@ -242,7 +249,8 @@
             "required": [
                 "byteSequenceId",
                 "byteSequenceIdNamespace"
-            ]
+            ],
+            "additionalProperties": false
         },
         "developerInformation": {
             "type": "object",
@@ -266,7 +274,27 @@
             "required": [
                 "developerId",
                 "developerIdNamespace"
-            ]
+            ],
+            "additionalProperties": false
+        },
+        "registryVersionInformation": {
+            "type": "object",
+            "properties": {
+                "registryNamespace": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "version": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "registryNamespace",
+                "version"
+            ],
+            "additionalProperties": false
         }
     },
     "title": "Format",
@@ -329,67 +357,67 @@
             "format": "date"
         },
         "provenance": {
-            "$ref": "#/definitions/provenanceInformation"
+            "$ref": "http://www.parcore.org/schema/format.json/#/definitions/provenanceInformation"
         },
         "lastUpdatedDate": {
             "type": "string",
             "format": "date"
         },
         "note": {
-            "type": "string",
+            "type": "string"
         },
         "risk": {
-            "type": "string",
+            "type": "string"
         },
         "technicalEnvironment": {
-            "$ref": "#/definitions/environmentInformation"
+            "$ref": "http://www.parcore.org/schema/format.json/#/definitions/environmentInformation"
         },
         "identifiers": {
             "type": "array",
             "items": {
-                "$ref": "#/definitions/identifierInformation"
+                "$ref": "http://www.parcore.org/schema/format.json/#/definitions/identifierInformation"
             }
         },
         "developers": {
             "type": "array",
             "items": {
-                "$ref": "#/definitions/developerInformation"
+                "$ref": "http://www.parcore.org/schema/format.json/#/definitions/developerInformation"
             }
         },
         "documents": {
             "type": "array",
             "items": {
-                "$ref": "#/definitions/documentInformation"
+                "$ref": "http://www.parcore.org/schema/format.json/#/definitions/documentInformation"
             }
         },
         "externalSignatures": {
             "type": "array",
             "items": {
-                "$ref": "#/definitions/externalSignatureInformation"
+                "$ref": "http://www.parcore.org/schema/format.json/#/definitions/externalSignatureInformation"
             }
         },
         "internalSignatures": {
             "type": "array",
             "items": {
-                "$ref": "#/definitions/internalSignatureInformation"
+                "$ref": "http://www.parcore.org/schema/format.json/#/definitions/internalSignatureInformation"
             }
         },
         "relatedFormats": {
             "type": "array",
             "items": {
-                "$ref": "#/definitions/relatedFormatInformation"
+                "$ref": "http://www.parcore.org/schema/format.json/#/definitions/relatedFormatInformation"
             }
         },
-        "droidSignatureFileVersion": {
-            "type": "string"
-        },
-        "droidContainerFileVersion": {
-            "type": "string"
+        "registryVersions": {
+            "type": "array",
+            "items": {
+                "$ref": "http://www.parcore.org/schema/format.json/#/definitions/registryVersionInformation"
+            }
         },
         "localLastModifiedDate": {
             "type": "string",
             "format": "date-time"
-        },
+        }
     },
     "required": [
         "puid",

--- a/schemas/preservation_action.json
+++ b/schemas/preservation_action.json
@@ -1,4 +1,5 @@
 {
+    "$id": "http://www.parcore.org/schema/preservation_action.json/#",
     "$schema": "http://json-schema.org/draft-06/schema#",
     "definitions": {
         "preservationActionType": {
@@ -25,28 +26,6 @@
             ],
             "additionalProperties": false
         },
-        "businessRule": {
-            "description": "this is a place holder for a proper definition of businessrules",
-            "title": "Business Rule",
-            "type": "object",
-            "properties": {
-                "businessRuleDetails": {
-                    "type": "string"
-                }
-            },
-            "additionalProperties": false
-        },
-        "file": {
-            "title": "File",
-            "description": "placeholder for File as defined by PCDM",
-            "type": "object",
-            "properties": {
-                "fileDetails": {
-                    "type": "string"
-                }
-            },
-            "additionalProperties": false
-        },
         "parProperty": {
             "description": "this is a skeleton definition of a Property",
             "title": "PAR Property",
@@ -57,45 +36,191 @@
                     "type": "string"
                 },
                 "parPropertyType": {
-                    "description": "Property Type is the class into which a specific property falls, e.g. fmt/43 is a file format, MD5 and SHA512 are both checksums, PASS and FAIL are both format validity measures.",          
-                    "enum": [            "checksum",            "file format",            "validity",            "size",            "other"          ]        }      },      
-                    "additionalProperties": false    },    
-                    "tool": {      "description": "this is a place holder for a proper definition of a Tool",      "title": "Tool",      "type": "object",      "properties": {        "toolName": {          "type": "string"        },        "toolDetails": {          "type": "string"        }      },      "additionalProperties": false    }  },  "title": "Preservation Action",  "type": "object",  "properties": {    "preservationActionID": {      "type": "string"    },    "preservationActionDescription": {      "type": "string"    },    "preservationActionType": {      "$ref": "#/definitions/preservationActionType"    },    "businessRules": {      "type": "array",      "items": {        "$ref": "#/definitions/businessRule"      },      "minItems": 0    },    "inputs": {      "type": "array",      "items": {        "anyOf": [          {            "$ref": "#/definitions/file"          },          {            "$ref": "#/definitions/parProperty"          }        ]      },      "minItems": 1,      "additionalItems": false    },    "outputs": {      "type": "array",      "items": {
-        "anyOf": [
-                        {
-                            "$ref": "#/definitions/file"
-                        },
-                        {
-                            "$ref": "#/definitions/parProperty"
-                        }
+                    "description": "Property Type is the class into which a specific property falls, e.g. fmt/43 is a file format, MD5 and SHA512 are both checksums, PASS and FAIL are both format validity measures.",
+                    "enum": [
+                        "checksum",
+                        "file format",
+                        "validity",
+                        "size",
+                        "other"
+                    ]
+                }
+            },
+            "additionalProperties": false
+        },
+        "inputItem": {
+            "description": "An input to a preservation action",
+            "title": "Preservation Action Input",
+            "type": "object",
+            "properties": {
+                "inputItemName": {
+                    "type": "string"
+                },
+                "inputItemType": {
+                    "enum": [
+                        "File",
+                        "string",
+                        "boolean",
+                        "integer",
+                        "stdin"
                     ]
                 },
-                "minItems": 1,
-                "additionalItems": false
-            },
-            "constraints": {
-                "type": "array",
-                "items": {
-                    "$ref": "#/definitions/parProperty"
+                "inputItemDescription": {
+                    "type": "string"
                 },
-                "minItems": 1,
-                "additionalItems": false
-            },
-            "tools": {
-                "type": "array",
-                "items": {
-                    "$ref": "#/definitions/tool"
+                "inputItemBinding": {
+                    "type": "object",
+                    "properties": {
+                        "prefix": {
+                            "type": "string"
+                        },
+                        "position": {
+                            "type": "integer"
+                        }
+                    }
                 },
-                "minItems": 1,
-                "additionalItems": false
-            }
+                "secondaryFiles": {
+                    "type": "array",
+                    "description": "files that need to be present when a tool is run, but are not listed on the command line",
+                    "minItems": 1,
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "secondaryFileDescription": {
+                                "type": "string"
+                            },
+                            "secondaryFileName": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "required": [
+                "inputItemName",
+                "inputItemType",
+                "inputItemBinding"
+            ],
+            "additionalProperties": false
         },
-        "required": [
-            "preservationActionID",
-            "preservationActionDescription",
-            "preservationActionType",
-            "inputs",
-            "outputs",
-            "tools"
-        ]
-    }
+        "outputItem": {
+            "description": "An output from a preservation action",
+            "title": "Preservation Action Output",
+            "type": "object",
+            "properties": {
+                "outputItemName": {
+                    "type": "string"
+                },
+                "outputItemDescription": {
+                    "type": "string"
+                },
+                "outputItemType": {
+                    "enum": [
+                        "File",
+                        "stdout",
+                        "stderr"
+                    ]
+                },
+                "outputItemBinding": {
+                    "type": "object",
+                    "properties": {
+                        "glob": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "outputItemMapping": {
+                    "type": "object",
+                    "properties": {
+                        "mappingExpressionType": {
+                            "enum": [
+                                "shellScript",
+                                "javaScript",
+                                "XPath"
+                            ]
+                        },
+                        "mappingExpression": {
+                            "type": "string"
+                        },
+                        "mapping": {
+                            "parPropertyId": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            },
+            "additionalProperties": false
+        },
+        "tool": {
+            "description": "this is a place holder for a proper definition of a Tool",
+            "title": "Tool",
+            "type": "object",
+            "properties": {
+                "toolIdentifier": {
+                    "type": "string"
+                },
+                "toolName": {
+                    "type": "string"
+                },
+                "toolDetails": {
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false
+        }
+    },
+    "title": "Preservation Action",
+    "type": "object",
+    "properties": {
+        "preservationActionID": {
+            "type": "string"
+        },
+        "preservationActionDescription": {
+            "type": "string"
+        },
+        "preservationActionExample": {
+            "type": "string"
+        },
+        "preservationActionType": {
+            "$ref": "http://www.parcore.org/schema/preservation_action.json/#/definitions/preservationActionType"
+        },
+        "inputs": {
+            "type": "array",
+            "items": {
+                "$ref": "http://www.parcore.org/schema/preservation_action.json/#/definitions/inputItem"
+            },
+            "minItems": 1,
+            "additionalItems": false
+        },
+        "outputs": {
+            "type": "array",
+            "items": {
+                "$ref": "http://www.parcore.org/schema/preservation_action.json/#/definitions/outputItem"
+            },
+            "minItems": 1,
+            "additionalItems": false
+        },
+        "constraints": {
+            "type": "array",
+            "items": {
+                "$ref": "http://www.parcore.org/schema/preservation_action.json/#/definitions/parProperty"
+            },
+            "minItems": 1,
+            "additionalItems": false
+        },
+        "tool": {
+            "$ref": "http://www.parcore.org/schema/preservation_action.json/#/definitions/tool",
+            "minItems": 1,
+            "additionalItems": false
+        }
+    },
+    "required": [
+        "preservationActionID",
+        "preservationActionDescription",
+        "preservationActionType",
+        "inputs",
+        "outputs",
+        "tool"
+    ]
+}

--- a/schemas/tool.json
+++ b/schemas/tool.json
@@ -1,5 +1,5 @@
 {
-    "id": "https://www.jisc.ac.uk/par/schema/tool_schema.json/#",
+    "$id": "http://www.parcore.org/schema/tool.json/#",
     "$schema": "http://json-schema.org/draft-06/schema#",
     "definitions": {
         "tool": {
@@ -22,17 +22,17 @@
                     "type": "string"
                 },
                 "toolAcceptedParameters": {
-                "type": "array",
-                "uniqueItems": true,
-                "items": {
-                    "$ref": "https://www.jisc.ac.uk/par/schema/types.json/#/definitions/parameter"
+                    "type": "array",
+                    "uniqueItems": true,
+                    "items": {
+                        "$ref": "http://www.parcore.org/schema/types.json/#/definitions/parameter"
                     }
                 },
                 "toolOperatingEnvironments": {
-                "type": "array",
-                "uniqueItems": true,
-                "items": {
-                    "type": "string"
+                    "type": "array",
+                    "uniqueItems": true,
+                    "items": {
+                        "type": "string"
                     }
                 }
             },

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python
+
+from abc import ABCMeta, abstractmethod
+import json
+import os
+import sys
+from unittest import TestCase, TestSuite, TextTestRunner
+
+from jsonschema import validate, FormatChecker, RefResolver
+
+
+class AbstractSchemaValidatorTest(object):
+    __metaclass__ = ABCMeta
+
+    schema_id_path_pairs = [
+        (
+            "http://www.parcore.org/schema/format.json/#",
+            "schemas/format.json"
+        ),
+        (
+            "http://www.parcore.org/schema/preservation_action.json/#",
+            "schemas/preservation_action.json"
+        ),
+        (
+            "http://www.parcore.org/schema/tool.json/#",
+            "schemas/tool.json"
+        ),
+    ]
+
+    dir_path = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+
+    @abstractmethod
+    def get_json_schema_file_name(self):
+        pass
+
+    def validate_json(self, json_file_name):
+        json_schema = self.get_json(self.get_json_schema_file_name())
+        json_data = self.get_json(json_file_name)
+        validate(
+            json_data,
+            json_schema,
+            resolver=RefResolver('', {}, store={
+                schema_id: self.get_json(schema_path)
+                for schema_id, schema_path in self.schema_id_path_pairs
+            }),
+            format_checker=FormatChecker(),
+        )
+
+    def get_json(self, file_name):
+        with open(self.prepare_file_name(file_name)) as json_data:
+            return json.load(json_data)
+
+    def prepare_file_name(self, file_name):
+        return self.dir_path + '/' + file_name
+
+
+class FormatTest(AbstractSchemaValidatorTest, TestCase):
+    def get_json_schema_file_name(self):
+        return 'schemas/format.json'
+
+    def runTest(self):
+        self.validate_json('examples/fmt-43.json')
+
+
+class PreservationActionTest(AbstractSchemaValidatorTest, TestCase):
+    def get_json_schema_file_name(self):
+        return 'schemas/preservation_action.json'
+
+    def runTest(self):
+        self.validate_json('examples/md5check.json')
+
+
+class ToolTest(AbstractSchemaValidatorTest, TestCase):
+    def get_json_schema_file_name(self):
+        return 'schemas/tool.json'
+
+    def runTest(self):
+        self.validate_json('examples/md5sum.json')
+
+
+def suite():
+    suite = TestSuite()
+    suite.addTest(FormatTest())
+    suite.addTest(PreservationActionTest())
+    suite.addTest(ToolTest())
+    return suite
+
+
+def main():
+    runner = TextTestRunner()
+    test_suite = suite()
+    result = runner.run(test_suite)
+    if len(result.errors) > 0:
+        return 1
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
This relates to #5.

It's based on the validator found at [rdss-message-api-specification](https://github.com/JiscRDSS/rdss-message-api-specification).

Usage:

```
$ virtualenv --python=python3.6 .tox/env
$ source .tox/env/bin/activate
$ pip install -r requirements.txt
$ ./tests/runner.py
```

At the moment, the validator breaks when the value of `$ref` uses a JSON pointer with relative values, e.g. a document using the following pointer won't validate:

    { "$ref": "#/definitions/preservationActionType" }

Use the following form instead:

    { "$ref": "http://www.parcore.org/schema/preservation_action.json/#/definitions/preservationActionType" }

---

573f503 (**optional**) brings #3 and #4 so they pass the tests.