### PR TITLE
split out property, added test and example

### DIFF
--- a/examples/cwl/echo/echo.cwl
+++ b/examples/cwl/echo/echo.cwl
@@ -1,0 +1,9 @@
+cwlVersion: v1.0
+class: CommandLineTool
+baseCommand: echo
+inputs:
+  message:
+    type: string
+    inputBinding:
+      position: 1
+outputs: []

--- a/examples/cwl/echo/echo.yml
+++ b/examples/cwl/echo/echo.yml
@@ -1,0 +1,1 @@
+message: Hello World

--- a/examples/cwl/md5check/manifest.md5
+++ b/examples/cwl/md5check/manifest.md5
@@ -1,0 +1,1 @@
+286dd22b4dbb990abe6e6489ad3c1375  testfile.txt

--- a/examples/cwl/md5check/md5check.cwl
+++ b/examples/cwl/md5check/md5check.cwl
@@ -1,0 +1,26 @@
+cwlVersion: v1.0
+class: CommandLineTool
+id: "md5check"
+label: "Fixity check using md5sum"
+baseCommand: md5sum
+
+requirements:
+  InitialWorkDirRequirement:
+    listing:
+      - $(inputs.input_file)
+
+inputs:
+  manifest_file:    
+    type: File
+    inputBinding:
+      prefix: -c
+      separate: true
+      position: 1 
+  input_file:    
+    type: File
+    
+outputs: 
+  fixity_report:
+    type: stdout
+stdout: fixity_report.txt
+

--- a/examples/cwl/md5check/md5check.yml
+++ b/examples/cwl/md5check/md5check.yml
@@ -1,0 +1,6 @@
+manifest_file:
+  class: File
+  path: manifest.md5
+input_file:
+  class: File
+  path: testfile.txt

--- a/examples/cwl/md5check/testfile.txt
+++ b/examples/cwl/md5check/testfile.txt
@@ -1,0 +1,1 @@
+PARcore, you know the score!

--- a/examples/md5check.json
+++ b/examples/md5check.json
@@ -40,6 +40,7 @@
         }
     ],
     "tool": {
-        "toolIdentifier": "md5sum"
+        "toolID": "md5sum",
+        "toolName": "md5sum"
     }
 }

--- a/examples/md5check.json
+++ b/examples/md5check.json
@@ -1,46 +1,46 @@
 {
-    "preservationActionName": "MD5 Checksum Validation Using md5sum",
-    "preservationActionID": "MD5CheckMD5Sum",
-    "preservationActionDescription": "Validation of an MD5 checksum on a File using md5sum",
-    "preservationActionExample": " commandline 'md5sum -c manifest.md5', where manifest.md5 contains a MD5 checksum for a file called inputfile",
-    "preservationActionType": {
-        "id": "fix",
-        "label": "fixity check",
-        "uri": "http://id.loc.gov/vocabulary/preservation/eventType/fix"
+  "preservationActionName": "MD5 Checksum Validation Using md5sum",
+  "preservationActionID": "MD5CheckMD5Sum",
+  "preservationActionDescription": "Validation of an MD5 checksum on a File using md5sum",
+  "preservationActionExample": " commandline 'md5sum -c manifest.md5', where manifest.md5 contains a MD5 checksum for a file called inputfile",
+  "preservationActionType": {
+    "id": "fix",
+    "label": "fixity check",
+    "uri": "http://id.loc.gov/vocabulary/preservation/eventType/fix"
+  },
+  "inputs": [
+    {
+      "inputItemName": "manifest.md5",
+      "inputItemType": "File",
+      "inputItemDescription": "Manifest file containing the MD5 and name of the file to be checked",
+      "inputItemBinding": {
+        "prefix": "-c",
+        "position": 1
+      }
     },
-    "inputs": [
-        {
-            "inputItemName": "manifest.md5",
-            "inputItemType": "File",
-            "inputItemDescription": "Manifest file containing the MD5 and name of the file to be checked",
-            "inputItemBinding": {
-                "prefix": "-c",
-                "position": 1
-            },
-            "secondaryFiles": [
-                {
-                    "secondaryFileName": "inputfile",
-                    "secondaryFileDescription": "The file that needs checking"
-                }
-            ]
-        }
-    ],
-    "outputs": [
-        {
-            "outputItemName": "pass_fail",
-            "outputItemDescription": "Fixity PASS or FAIL",
-            "outputItemType": "stdout",
-            "outputItemMapping": {
-                "outputMappingExpression": "grep -o -e 'FAILED' -e 'OK' | sed 's/OK/PASS/g' | sed 's/FAILED/FAIL/g'",
-                "outputMappingExpressionType": "shell script",
-                "outputMapping": {
-                    "parPropertyId": "fixityStatus"
-                }
-            }
-        }
-    ],
-    "tool": {
-        "toolID": "md5sum",
-        "toolName": "md5sum"
+    {
+      "inputItemName": "inputfile",
+      "inputItemType": "File",
+      "inputItemDescription": "File that will be fixity checked"
     }
+  ],
+  "outputs": [
+    {
+      "outputItemName": "pass_fail",
+      "outputItemDescription": "Fixity PASS or FAIL",
+      "outputItemType": "stdout",
+      "outputItemMapping": {
+        "outputMappingExpression": "grep -o -e 'FAILED' -e 'OK' | sed 's/OK/PASS/g' | sed 's/FAILED/FAIL/g'",
+        "outputMappingExpressionType": "shell script",
+        "outputMapping": {
+          "parPropertyId": "fixityStatus"
+        }
+      }
+    }
+  ],
+  "tool": {
+    "toolID": "md5sum",
+    "toolName": "md5sum"
+  }
 }
+

--- a/examples/md5prop.json
+++ b/examples/md5prop.json
@@ -1,0 +1,4 @@
+{
+  "parPropertyName": "MD5",
+  "parPropertyType": "checksum"
+}

--- a/schemas/par_property.json
+++ b/schemas/par_property.json
@@ -1,0 +1,24 @@
+{
+  "$id": "http://www.parcore.org/schema/par_property.json/#",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "description": "this is a skeleton definition of a Property",
+  "title": "PAR Property",
+  "type": "object",
+  "properties": {
+    "parPropertyName": {
+      "description": "Property Name is a specific property, e.g. fmt/43, MD5, SHA512, PASS, FAIL, number of bytes etc.",
+      "type": "string"
+    },
+    "parPropertyType": {
+      "description": "Property Type is the class into which a specific property falls, e.g. fmt/43 is a file format, MD5 and SHA512 are both checksums, PASS and FAIL are both format validity measures.",
+      "enum": [
+        "checksum",
+        "file format",
+        "validity",
+        "size",
+        "other"
+      ]
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/preservation_action.json
+++ b/schemas/preservation_action.json
@@ -1,202 +1,163 @@
 {
-    "$id": "http://www.parcore.org/schema/preservation_action.json/#",
-    "$schema": "http://json-schema.org/draft-06/schema#",
-    "definitions": {
-      "parProperty": {
-        "description": "this is a skeleton definition of a Property",
-        "title": "PAR Property",
-        "type": "object",
-        "properties": {
-          "parPropertyName": {
-            "description": "Property Name is a specific property, e.g. fmt/43, MD5, SHA512, PASS, FAIL, number of bytes etc.",
-            "type": "string"
-          },
-          "parPropertyType": {
-            "description": "Property Type is the class into which a specific property falls, e.g. fmt/43 is a file format, MD5 and SHA512 are both checksums, PASS and FAIL are both format validity measures.",
-            "enum": [
-              "checksum",
-              "file format",
-              "validity",
-              "size",
-              "other"
-            ]
+  "$id": "http://www.parcore.org/schema/preservation_action.json/#",
+  "$schema": "http://json-schema.org/draft-06/schema#",
+  "definitions": {
+    "inputItem": {
+      "description": "An input to a preservation action",
+      "title": "Preservation Action Input",
+      "type": "object",
+      "properties": {
+        "inputItemName": {
+          "type": "string"
+        },
+        "inputItemType": {
+          "enum": [
+            "File",
+            "string",
+            "boolean",
+            "integer",
+            "stdin"
+          ]
+        },
+        "inputItemDescription": {
+          "type": "string"
+        },
+        "inputItemBinding": {
+          "type": "object",
+          "properties": {
+            "prefix": {
+              "type": "string"
+            },
+            "position": {
+              "type": "integer"
+            }
           }
         },
-        "additionalProperties": false
-      },
-      "inputItem": {
-        "description": "An input to a preservation action",
-        "title": "Preservation Action Input",
-        "type": "object",
-        "properties": {
-          "inputItemName": {
-            "type": "string"
-          },
-          "inputItemType": {
-            "enum": [
-              "File",
-              "string",
-              "boolean",
-              "integer",
-              "stdin"
-            ]
-          },
-          "inputItemDescription": {
-            "type": "string"
-          },
-          "inputItemBinding": {
+        "secondaryFiles": {
+          "type": "array",
+          "description": "files that need to be present when a tool is run, but are not listed on the command line",
+          "minItems": 1,
+          "items": {
             "type": "object",
             "properties": {
-              "prefix": {
+              "secondaryFileDescription": {
                 "type": "string"
               },
-              "position": {
-                "type": "integer"
-              }
-            }
-          },
-          "secondaryFiles": {
-            "type": "array",
-            "description": "files that need to be present when a tool is run, but are not listed on the command line",
-            "minItems": 1,
-            "items": {
-              "type": "object",
-              "properties": {
-                "secondaryFileDescription": {
-                  "type": "string"
-                },
-                "secondaryFileName": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        },
-        "required": [
-          "inputItemName",
-          "inputItemType",
-          "inputItemBinding"
-        ],
-        "additionalProperties": false
-      },
-      "outputItem": {
-        "description": "An output from a preservation action",
-        "title": "Preservation Action Output",
-        "type": "object",
-        "properties": {
-          "outputItemName": {
-            "type": "string"
-          },
-          "outputItemDescription": {
-            "type": "string"
-          },
-          "outputItemType": {
-            "enum": [
-              "File",
-              "stdout",
-              "stderr"
-            ]
-          },
-          "outputItemBinding": {
-            "type": "object",
-            "properties": {
-              "glob": {
+              "secondaryFileName": {
                 "type": "string"
               }
             }
-          },
-          "outputItemMapping": {
-            "type": "object",
-            "properties": {
-              "mappingExpressionType": {
-                "enum": [
-                  "shellScript",
-                  "javaScript",
-                  "XPath"
-                ]
-              },
-              "mappingExpression": {
-                "type": "string"
-              },
-              "mapping": {
-                "parPropertyId": {
-                  "type": "string"
-                }
-              }
-            }
           }
-        },
-        "additionalProperties": false
+        }
       },
-      "tool": {
-        "description": "this is a place holder for a proper definition of a Tool",
-        "title": "Tool",
-        "type": "object",
-        "properties": {
-          "toolIdentifier": {
-            "type": "string"
-          },
-          "toolName": {
-            "type": "string"
-          },
-          "toolDetails": {
-            "type": "string"
-          }
-        },
-        "additionalProperties": false
-      }
+      "required": [
+        "inputItemName",
+        "inputItemType",
+        "inputItemBinding"
+      ],
+      "additionalProperties": false
     },
-    "title": "Preservation Action",
-    "type": "object",
-    "properties": {
-      "preservationActionID": {
-        "type": "string"
-      },
-      "preservationActionDescription": {
-        "type": "string"
-      },
-      "preservationActionExample": {
-        "type": "string"
-      },
-      "preservationActionType": {
-        "$ref": "http://www.parcore.org/schema/preservation_action_type.json/#"
-      },
-      "inputs": {
-        "type": "array",
-        "items": {
-          "$ref": "http://www.parcore.org/schema/preservation_action.json/#/definitions/inputItem"
+    "outputItem": {
+      "description": "An output from a preservation action",
+      "title": "Preservation Action Output",
+      "type": "object",
+      "properties": {
+        "outputItemName": {
+          "type": "string"
         },
-        "minItems": 1,
-        "additionalItems": false
-      },
-      "outputs": {
-        "type": "array",
-        "items": {
-          "$ref": "http://www.parcore.org/schema/preservation_action.json/#/definitions/outputItem"
+        "outputItemDescription": {
+          "type": "string"
         },
-        "minItems": 1,
-        "additionalItems": false
-      },
-      "constraints": {
-        "type": "array",
-        "items": {
-          "$ref": "http://www.parcore.org/schema/preservation_action.json/#/definitions/parProperty"
+        "outputItemType": {
+          "enum": [
+            "File",
+            "stdout",
+            "stderr"
+          ]
         },
-        "minItems": 1,
-        "additionalItems": false
+        "outputItemBinding": {
+          "type": "object",
+          "properties": {
+            "glob": {
+              "type": "string"
+            }
+          }
+        },
+        "outputItemMapping": {
+          "type": "object",
+          "properties": {
+            "mappingExpressionType": {
+              "enum": [
+                "shellScript",
+                "javaScript",
+                "XPath"
+              ]
+            },
+            "mappingExpression": {
+              "type": "string"
+            },
+            "mapping": {
+              "parPropertyId": {
+                "type": "string"
+              }
+            }
+          }
+        }
       },
-      "tool": {
-        "$ref": "http://www.parcore.org/schema/preservation_action.json/#/definitions/tool",
-        "minItems": 1,
-        "additionalItems": false
-      }
+      "additionalProperties": false
+    }
+  },
+  "title": "Preservation Action",
+  "type": "object",
+  "properties": {
+    "preservationActionID": {
+      "type": "string"
     },
-    "required": [
-      "preservationActionID",
-      "preservationActionDescription",
-      "preservationActionType",
-      "inputs",
-      "outputs",
-      "tool"
-    ]
+    "preservationActionDescription": {
+      "type": "string"
+    },
+    "preservationActionExample": {
+      "type": "string"
+    },
+    "preservationActionType": {
+      "$ref": "http://www.parcore.org/schema/preservation_action_type.json/#"
+    },
+    "inputs": {
+      "type": "array",
+      "items": {
+        "$ref": "http://www.parcore.org/schema/preservation_action.json/#/definitions/inputItem"
+      },
+      "minItems": 1,
+      "additionalItems": false
+    },
+    "outputs": {
+      "type": "array",
+      "items": {
+        "$ref": "http://www.parcore.org/schema/preservation_action.json/#/definitions/outputItem"
+      },
+      "minItems": 1,
+      "additionalItems": false
+    },
+    "constraints": {
+      "type": "array",
+      "items": {
+        "$ref": "http://www.parcore.org/schema/par_property.json/#"
+      },
+      "minItems": 1,
+      "additionalItems": false
+    },
+    "tool": {
+      "$ref": "http://www.parcore.org/schema/tool.json/#",
+      "minItems": 1,
+      "additionalItems": false
+    }
+  },
+  "required": [
+    "preservationActionID",
+    "preservationActionDescription",
+    "preservationActionType",
+    "inputs",
+    "outputs",
+    "tool"
+  ]
 }

--- a/schemas/preservation_action.json
+++ b/schemas/preservation_action.json
@@ -52,8 +52,7 @@
       },
       "required": [
         "inputItemName",
-        "inputItemType",
-        "inputItemBinding"
+        "inputItemType"
       ],
       "additionalProperties": false
     },
@@ -147,7 +146,7 @@
       "additionalItems": false
     },
     "tool": {
-      "$ref": "http://www.parcore.org/schema/tool.json/#",
+      "$ref": "http://www.parcore.org/schema/tool.json/#/definitions/tool",
       "minItems": 1,
       "additionalItems": false
     }

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -33,6 +33,10 @@ class AbstractSchemaValidatorTest(object):
             "http://www.parcore.org/schema/types.json/#",
             "schemas/types.json"
         ),
+                (
+            "http://www.parcore.org/schema/par_property.json/#",
+            "schemas/par_property.json"
+        ),
     ]
 
     dir_path = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
@@ -85,12 +89,19 @@ class ToolTest(AbstractSchemaValidatorTest, TestCase):
     def runTest(self):
         self.validate_json('examples/md5sum.json')
 
+class PropertyTest(AbstractSchemaValidatorTest, TestCase):
+    def get_json_schema_file_name(self):
+        return 'schemas/par_property.json'
+
+    def runTest(self):
+        self.validate_json('examples/md5prop.json')
 
 def suite():
     suite = TestSuite()
     suite.addTest(FormatTest())
     suite.addTest(PreservationActionTest())
     suite.addTest(ToolTest())
+    suite.addTest(PropertyTest())
     return suite
 
 


### PR DESCRIPTION
I've split out parProperty into its own schema file.  I updated Preservation Action to reference this schema and also the tools.json one.   I updated the md5check example.  I added a test to runner.py.   I tested on my local repo and the runner.py passes all the tests OK including the new one for parProperty (md5prop.json) and also the updated md5check.json.

Connects to #13 