### PR TITLE
TEST - JSON lint for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,6 @@ language: python
 python:
   - "2.7"
   - "3.4"
-script: pytest
+script:
+  - ./scripts/lint-json-dirs
+  - pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+demjson
 jsonschema

--- a/scripts/lint-json-dirs
+++ b/scripts/lint-json-dirs
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Grab the execution directory
+SCRIPT_DIR="$( dirname "$( readlink -f "${BASH_SOURCE[0]}" )")"
+OUTPUT_SEP="==================================="
+
+# Define variables for the directory to lint
+lintDirJson() {
+  echo "JSONLINT - All files in dir $1."
+  echo $OUTPUT_SEP
+  for file in $SCRIPT_DIR/../$1/*.json; do
+    jsonlint $file
+    exitStatus=$?
+    if [[ $exitStatus -ne 0 ]]
+    then
+      exit $exitStatus
+    fi
+  done
+  echo ""
+}
+
+lintDirJson "schemas"
+lintDirJson "api"
+lintDirJson "examples"


### PR DESCRIPTION
- using https://deron.meranda.us/python/demjson/ for JSON lint;
- `./scripts/lint-json-dirs` bash script to:
  - loop through `*.json` in `./api`, `./examples`, and `schemas`;
  - run `jsonlint` on those files; and
  - `exit` with non-zero code on failure (for Travis).
- added test script to `.travis.yml`; and
- added `demjson` to `requirements.txt`.