### PR TITLE
Modified preservation action to have separate lists of inputs and out…

### DIFF
--- a/examples/br-3.json
+++ b/examples/br-3.json
@@ -125,22 +125,20 @@
   ],
   "preservationActions": [
     {
-      "optionalInputs": [
+      "optionalInputProperties": [
         {
           "description": "Resize to fit a 250px square box",
           "name": "250x250",
-          "type": {
-            "parProperty": {
-              "class": "size",
-              "id": {
-                "guid": "iab747c2a-9c2f-4e79-9ac8-d12015398d32",
-                "name": "2D resolution",
-                "namespace": "http://www.parcore.org/properties"
-              },
-              "type": "string",
-              "units": "pixels",
-              "value": "250x250"
-            }
+          "parProperty": {
+            "class": "size",
+            "id": {
+              "guid": "iab747c2a-9c2f-4e79-9ac8-d12015398d32",
+              "name": "2D resolution",
+              "namespace": "http://www.parcore.org/properties"
+            },
+            "type": "string",
+            "units": "pixels",
+            "value": "250x250"
           }
         }
       ],

--- a/examples/md5check1.json
+++ b/examples/md5check1.json
@@ -6,36 +6,30 @@
     "name": "MD5CheckMD5Sum",
     "namespace": "http://www.parcore.org/actions"
   },
-  "inputs": [
+  "inputFiles": [
     {
       "description": "Manifest file containing the MD5 and name of the file to be checked",
-      "name": "manifest.md5",
-      "type": {
-        "file": {
-          "filepath": ""
-        }
-      }
+      "file": {
+        "filepath": ""
+      },
+      "name": "manifest.md5"
     },
     {
       "description": "File that will be fixity checked",
-      "name": "inputfile",
-      "type": {
-        "file": {
-          "filepath": ""
-        }
-      }
-    }
-  ],
-  "outputs": [
-    {
-      "description": "Fixity PASS or FAIL",
-      "name": "pass_fail",
-      "type": {
-        "raw": ""
-      }
+      "file": {
+        "filepath": ""
+      },
+      "name": "inputfile"
     }
   ],
   "preservationActionName": "MD5 Checksum Validation Using md5sum",
+  "rawOutputs": [
+    {
+      "description": "Fixity PASS or FAIL",
+      "name": "pass_fail",
+      "value": ""
+    }
+  ],
   "tool": {
     "toolID": "md5sum",
     "toolName": "md5sum"

--- a/examples/md5check2.json
+++ b/examples/md5check2.json
@@ -6,46 +6,42 @@
     "name": "MD5CheckMD5Sum2",
     "namespace": "http://www.parcore.org/actions"
   },
-  "inputs": [
+  "inputFiles": [
+    {
+      "description": "File that will be fixity checked",
+      "file": {
+        "filepath": ""
+      },
+      "name": "inputfile"
+    }
+  ],
+  "inputProperties": [
     {
       "description": "Checksum of the file to be checked",
       "name": "MD5 checksum",
-      "type": {
-        "parProperty": {
-          "class": "checksum",
-          "id": {
-            "guid": "944a16dc-41f6-574e-99d0-2555497b74a4",
-            "name": "MD5",
-            "namespace": "http://www.parcore.org/properties"
-          },
-          "type": "string"
-        }
-      }
-    },
-    {
-      "description": "File that will be fixity checked",
-      "name": "inputfile",
-      "type": {
-        "file": {
-          "filepath": ""
-        }
+      "parProperty": {
+        "class": "checksum",
+        "id": {
+          "guid": "944a16dc-41f6-574e-99d0-2555497b74a4",
+          "name": "MD5",
+          "namespace": "http://www.parcore.org/properties"
+        },
+        "type": "string"
       }
     }
   ],
-  "outputs": [
+  "outputProperties": [
     {
       "description": "PASS if file matches the checksum, otherwise FAIL",
       "name": "PASS or FAIL",
-      "type": {
-        "parProperty": {
-          "class": "validity",
-          "id": {
-            "guid": "444d6f5f-ae27-4350-a951-0c1c0ae3ff34",
-            "name": "PASS FAIL",
-            "namespace": "http://www.parcore.org/properties"
-          },
-          "type": "string"
-        }
+      "parProperty": {
+        "class": "validity",
+        "id": {
+          "guid": "444d6f5f-ae27-4350-a951-0c1c0ae3ff34",
+          "name": "PASS FAIL",
+          "namespace": "http://www.parcore.org/properties"
+        },
+        "type": "string"
       }
     }
   ],

--- a/examples/mediaInfo2.json
+++ b/examples/mediaInfo2.json
@@ -33,64 +33,56 @@
     "name": "MediaInfo2",
     "namespace": "http://www.parcore.org/actions"
   },
-  "inputs": [
+  "inputFiles": [
     {
       "description": "File that will have metadata extracted from",
-      "name": "inputfile",
-      "type": {
-        "file": {
-          "filepath": ""
-        }
-      }
+      "file": {
+        "filepath": ""
+      },
+      "name": "inputfile"
     }
   ],
-  "outputs": [
+  "outputProperties": [
     {
       "description": "Width in pixels of the video",
       "name": "width",
-      "type": {
-        "parProperty": {
-          "class": "size",
-          "id": {
-            "guid": "ffc702fe-d4bb-5243-99b2-45a4ea28f7c2",
-            "name": "width",
-            "namespace": "https://www.ebu.ch/metadata/ontologies/ebucore"
-          },
-          "type": "integer",
-          "units": "pixel"
-        }
+      "parProperty": {
+        "class": "size",
+        "id": {
+          "guid": "ffc702fe-d4bb-5243-99b2-45a4ea28f7c2",
+          "name": "width",
+          "namespace": "https://www.ebu.ch/metadata/ontologies/ebucore"
+        },
+        "type": "integer",
+        "units": "pixel"
       }
     },
     {
       "description": "Height in pixels of the video",
       "name": "height",
-      "type": {
-        "parProperty": {
-          "class": "size",
-          "id": {
-            "guid": "526b1d5e-d176-4879-9e2c-47e429155c8f",
-            "name": "height",
-            "namespace": "https://www.ebu.ch/metadata/ontologies/ebucore"
-          },
-          "type": "integer",
-          "units": "pixel"
-        }
+      "parProperty": {
+        "class": "size",
+        "id": {
+          "guid": "526b1d5e-d176-4879-9e2c-47e429155c8f",
+          "name": "height",
+          "namespace": "https://www.ebu.ch/metadata/ontologies/ebucore"
+        },
+        "type": "integer",
+        "units": "pixel"
       }
     },
     {
       "description": "bitrate of the video",
       "name": "bitrate",
-      "type": {
-        "parProperty": {
-          "class": "rate",
-          "id": {
-            "guid": "5cb7a433-762b-465d-b227-9291779c2456",
-            "name": "bitrate",
-            "namespace": "https://www.ebu.ch/metadata/ontologies/ebucore"
-          },
-          "type": "integer",
-          "units": "bits per second"
-        }
+      "parProperty": {
+        "class": "rate",
+        "id": {
+          "guid": "5cb7a433-762b-465d-b227-9291779c2456",
+          "name": "bitrate",
+          "namespace": "https://www.ebu.ch/metadata/ontologies/ebucore"
+        },
+        "type": "integer",
+        "units": "bits per second"
       }
     }
   ],

--- a/schemas/business-rule.json
+++ b/schemas/business-rule.json
@@ -5,15 +5,21 @@
   "definitions": {
     "action": {
       "properties": {
-        "optionalInputs": {
+        "optionalInputProperties": {
           "items": {
-            "$ref": "http://www.parcore.org/schema/preservation-action.json/#/definitions/inputItem"
+            "$ref": "http://www.parcore.org/schema/preservation-action.json/#/definitions/inputProperty"
           },
           "type": "array"
         },
-        "outputsRetrieved": {
+        "outputFilesRetrieved": {
           "items": {
-            "$ref": "http://www.parcore.org/schema/preservation-action.json/#/definitions/outputItem"
+            "$ref": "http://www.parcore.org/schema/preservation-action.json/#/definitions/outputFile"
+          },
+          "type": "array"
+        },
+        "outputPropertiesRetrieved": {
+          "items": {
+            "$ref": "http://www.parcore.org/schema/preservation-action.json/#/definitions/outputProperty"
           },
           "type": "array"
         },
@@ -22,6 +28,12 @@
         },
         "priority": {
           "type": "integer"
+        },
+        "rawOutputsRetrieved": {
+          "items": {
+            "$ref": "http://www.parcore.org/schema/preservation-action.json/#/definitions/outputRaw"
+          },
+          "type": "array"
         }
       },
       "required": [

--- a/schemas/preservation-action.json
+++ b/schemas/preservation-action.json
@@ -1,49 +1,70 @@
 {
   "$id": "http://www.parcore.org/schema/preservation-action.json/#",
   "$schema": "http://json-schema.org/draft-06/schema#",
+  "anyOf": [
+    {
+      "required": [
+        "inputFiles",
+        "outputFiles"
+      ]
+    },
+    {
+      "required": [
+        "inputProperties",
+        "outputFiles"
+      ]
+    },
+    {
+      "required": [
+        "inputFiles",
+        "outputProperties"
+      ]
+    },
+    {
+      "required": [
+        "inputProperties",
+        "outputProperties"
+      ]
+    },
+    {
+      "required": [
+        "inputFiles",
+        "rawOutputs"
+      ]
+    },
+    {
+      "required": [
+        "inputProperties",
+        "rawOutputs"
+      ]
+    }
+  ],
   "definitions": {
-    "inputItem": {
+    "inputFile": {
       "additionalProperties": false,
-      "description": "An input to a preservation action",
+      "description": "A file input to a preservation action",
       "properties": {
         "description": {
           "type": "string"
         },
+        "file": {
+          "$ref": "http://www.parcore.org/schema/types.json/#/definitions/parFile"
+        },
         "name": {
           "type": "string"
-        },
-        "type": {
-          "anyOf": [
-            {
-              "properties": {
-                "file": {
-                  "$ref": "http://www.parcore.org/schema/types.json/#/definitions/parFile"
-                }
-              },
-              "type": "object"
-            },
-            {
-              "properties": {
-                "parProperty": {
-                  "$ref": "http://www.parcore.org/schema/par-property.json/#"
-                }
-              },
-              "type": "object"
-            }
-          ]
         }
       },
       "required": [
         "name",
         "description",
-        "type"
+        "file"
       ],
-      "title": "Preservation Action Input",
+      "title": "Preservation Action Input File",
       "type": "object"
     },
-    "outputItem": {
+    "inputProperty": {
       "additionalProperties": false,
-      "description": "An output from a preservation action",
+      "description": "A property input to a preservation action",
       "properties": {
         "description": {
           "type": "string"
@@ -51,41 +72,82 @@
         "name": {
           "type": "string"
         },
-        "type": {
-          "anyOf": [
-            {
-              "properties": {
-                "file": {
-                  "$ref": "http://www.parcore.org/schema/types.json/#/definitions/parFile"
-                }
-              },
-              "type": "object"
-            },
-            {
-              "properties": {
-                "parProperty": {
-                  "$ref": "http://www.parcore.org/schema/par-property.json/#"
-                }
-              },
-              "type": "object"
-            },
-            {
-              "properties": {
-                "raw": {
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            }
-          ]
+        "parProperty": {
+          "$ref": "http://www.parcore.org/schema/par-property.json/#"
         }
       },
       "required": [
         "name",
         "description",
-        "type"
+        "parProperty"
+      ],
+      "title": "Preservation Action Input Property",
+      "type": "object"
+    },
+    "outputFile": {
+      "additionalProperties": false,
+      "description": "An output file from a preservation action",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "file": {
+          "$ref": "http://www.parcore.org/schema/types.json/#/definitions/parFile"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "description",
+        "file"
+      ],
+      "title": "Preservation Action Output File",
+      "type": "object"
+    },
+    "outputProperty": {
+      "additionalProperties": false,
+      "description": "An output property from a preservation action",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "parProperty": {
+          "$ref": "http://www.parcore.org/schema/par-property.json/#"
+        }
+      },
+      "required": [
+        "name",
+        "description",
+        "parProperty"
       ],
       "title": "Preservation Action Output",
+      "type": "object"
+    },
+    "outputRaw": {
+      "additionalProperties": false,
+      "description": "A raw output from a preservation action",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "description",
+        "value"
+      ],
+      "title": "Preservation Action Raw Output",
       "type": "object"
     }
   },
@@ -130,22 +192,44 @@
     "id": {
       "$ref": "http://www.parcore.org/schema/types.json/#/definitions/parIdentifier"
     },
-    "inputs": {
+    "inputFiles": {
       "additionalItems": false,
       "items": {
-        "$ref": "http://www.parcore.org/schema/preservation-action.json/#/definitions/inputItem"
+        "$ref": "http://www.parcore.org/schema/preservation-action.json/#/definitions/inputFile"
       },
-      "minItems": 1,
+      "type": "array"
+    },
+    "inputProperties": {
+      "additionalItems": false,
+      "items": {
+        "$ref": "http://www.parcore.org/schema/preservation-action.json/#/definitions/inputProperty"
+      },
       "type": "array"
     },
     "localLastModifiedDate": {
       "format": "date-time",
       "type": "string"
     },
-    "outputs": {
+    "outputFiles": {
       "additionalItems": false,
       "items": {
-        "$ref": "http://www.parcore.org/schema/preservation-action.json/#/definitions/outputItem"
+        "$ref": "http://www.parcore.org/schema/preservation-action.json/#/definitions/outputFile"
+      },
+      "minItems": 1,
+      "type": "array"
+    },
+    "outputProperties": {
+      "additionalItems": false,
+      "items": {
+        "$ref": "http://www.parcore.org/schema/preservation-action.json/#/definitions/outputProperty"
+      },
+      "minItems": 1,
+      "type": "array"
+    },
+    "rawOutputs": {
+      "additionalItems": false,
+      "items": {
+        "$ref": "http://www.parcore.org/schema/preservation-action.json/#/definitions/outputRaw"
       },
       "minItems": 1,
       "type": "array"
@@ -161,8 +245,6 @@
     "id",
     "description",
     "type",
-    "inputs",
-    "outputs",
     "tool"
   ],
   "title": "Preservation Action",


### PR DESCRIPTION
…puts

In order to ease binding to strongly typed languages the arrays of "anyOf" have been split into separate lists of different types of inputs and outputs, the requirement for some input and output has been maintained through an "anyOf" required array which specifies each of the minimum combinations.